### PR TITLE
Make consistent use of length/size.

### DIFF
--- a/lib/helpers/string_helper.rb
+++ b/lib/helpers/string_helper.rb
@@ -11,25 +11,25 @@ class StringHelper
   PosInteger = And[Not[Neg], Integer]
 
   Contract PosInteger, Maybe[String] => String
-  # Return a string of the given size.
+  # Return a string of the given length.
   # Use trimmed or extended base_string, which defaults to 'x'.
-  def self.string_of_length(size, base_string = 'x')
-    raise ArgumentError.new('Size < 0: %d' % size) if size < 0
+  def self.string_of_length(length, base_string = 'x')
+    raise ArgumentError.new('length < 0: %d' % length) if length < 0
     case
-      when size == 0
+      when length == 0
         return ''
       when base_string.nil?
-        return 'x' * size
-      when base_string.size > size
+        return 'x' * length
+      when base_string.length > length
         # Trim.
-        return base_string[0..size-1]
+        return base_string[0..length-1]
       else
         # Extend.
         s = base_string
-        while s.size < size
+        while s.length < length
           s = s * 2
         end
-        return s[0..size-1]
+        return s[0..length-1]
     end
   end
 

--- a/test/helpers/string_helper_test.rb
+++ b/test/helpers/string_helper_test.rb
@@ -18,7 +18,7 @@ class StringHelperTest < Minitest::Test
         [4] => DEFAULT_BASE_STRING * 4,
         [0, BASE_STRING] => '',
         [1, BASE_STRING] => BASE_STRING[0],
-        [BASE_STRING.size * 2 - 1, BASE_STRING] => (BASE_STRING * 2)[0..-2],
+        [BASE_STRING.length * 2 - 1, BASE_STRING] => (BASE_STRING * 2)[0..-2],
     }.each_pair do |args, expected|
       actual = StringHelper.send(method, *args)
       assert_equal(expected, actual, args.inspect)
@@ -59,7 +59,7 @@ class StringHelperTest < Minitest::Test
         [(4..4), nil] => DEFAULT_BASE_STRING * 4,
         [(0..1), BASE_STRING] => '',
         [(1..1), BASE_STRING] => BASE_STRING[0],
-        [((BASE_STRING.size * 2 - 1)..100), BASE_STRING] => (BASE_STRING * 2)[0..-2],
+        [((BASE_STRING.length * 2 - 1)..100), BASE_STRING] => (BASE_STRING * 2)[0..-2],
     }.each_pair do |args, expected|
       range, base_string = *args
       actual = StringHelper.send(method, range, base_string)
@@ -99,7 +99,7 @@ class StringHelperTest < Minitest::Test
         [(0..4), nil] => DEFAULT_BASE_STRING * 4,
         [(0..0), BASE_STRING] => '',
         [(0..1), BASE_STRING] => BASE_STRING[0],
-        [(0..(BASE_STRING.size * 2 - 1)), BASE_STRING] => (BASE_STRING * 2)[0..-2],
+        [(0..(BASE_STRING.length * 2 - 1)), BASE_STRING] => (BASE_STRING * 2)[0..-2],
     }.each_pair do |args, expected|
       range, base_string = *args
       actual = StringHelper.send(method, range, base_string)
@@ -140,7 +140,7 @@ class StringHelperTest < Minitest::Test
         [(0..1), BASE_STRING] => nil,
         [(1..1), BASE_STRING] => '',
         [(2..2), BASE_STRING] => BASE_STRING[0],
-        [(BASE_STRING.size * 2 - 1)..(BASE_STRING.size * 2), BASE_STRING] => (BASE_STRING * 2)[0..-3],
+        [(BASE_STRING.length * 2 - 1)..(BASE_STRING.length * 2), BASE_STRING] => (BASE_STRING * 2)[0..-3],
     }.each_pair do |args, expected|
       range, base_string = *args
       actual = StringHelper.send(method, range, base_string)
@@ -185,7 +185,7 @@ class StringHelperTest < Minitest::Test
         [(0..3), nil] => StringHelper.string_of_length(4),
         [(0..0), BASE_STRING] => StringHelper.string_of_length(1, BASE_STRING),
         [(0..1), BASE_STRING] => StringHelper.string_of_length(2, BASE_STRING),
-        [0..(BASE_STRING.size * 2 - 1), BASE_STRING] => (BASE_STRING * 2)[0..-1],
+        [0..(BASE_STRING.length * 2 - 1), BASE_STRING] => (BASE_STRING * 2)[0..-1],
     }.each_pair do |args, expected|
       range, base_string = *args
       actual = StringHelper.send(method, range, base_string)


### PR DESCRIPTION
Chose length (though size is shorter) b/c it reads better in the method
names.