### PR TITLE
In REST API examples, changed abbreviated log-method names (aliases) …

### DIFF
--- a/examples/rest_api/data/address.rb
+++ b/examples/rest_api/data/address.rb
@@ -35,10 +35,10 @@ class Address < BaseClassForData
   Contract Log, String => Bool
   def verdict_valid?(log, verdict_id)
     if log.verdict_assert_instance_of?(verdict_id + ' - class', Address, self, 'First object is of class Address')
-      log.va_string_not_empty?(verdict_id + ' - street', self.street, 'Address street')
-      log.va_string_not_empty?(verdict_id + ' - suite', self.suite, 'Address suite')
-      log.va_string_not_empty?(verdict_id + ' - city', self.city, 'Address city')
-      log.va_string_not_empty?(verdict_id + ' - zipcode', self.zipcode, 'Address zipcode')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - street', self.street, 'Address street')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - suite', self.suite, 'Address suite')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - city', self.city, 'Address city')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - zipcode', self.zipcode, 'Address zipcode')
       geo.verdict_valid?(log, verdict_id + ' - geo')
     end
   end

--- a/examples/rest_api/data/album.rb
+++ b/examples/rest_api/data/album.rb
@@ -23,9 +23,9 @@ class Album < BaseClassForResource
   Contract Log, String => Bool
   def verdict_valid?(log, verdict_id)
     if log.verdict_assert_instance_of?(verdict_id + ' - class', Album, self, 'First object is of class Album')
-      log.va_integer_positive?(verdict_id + ' - id', self.id, 'Album id')
-      log.va_integer_positive?(verdict_id + ' - user id', self.userId, 'Album user id')
-      log.va_string_not_empty?(verdict_id + ' - title', self.title, 'Album title')
+      log.verdict_assert_integer_positive?(verdict_id + ' - id', self.id, 'Album id')
+      log.verdict_assert_integer_positive?(verdict_id + ' - user id', self.userId, 'Album user id')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - title', self.title, 'Album title')
     end
   end
 

--- a/examples/rest_api/data/comment.rb
+++ b/examples/rest_api/data/comment.rb
@@ -31,11 +31,11 @@ class Comment < BaseClassForResource
   Contract Log, String => Bool
   def verdict_valid?(log, verdict_id)
     if log.verdict_assert_instance_of?(verdict_id + ' - class', Comment, self, 'First object is of class Comment')
-      log.va_integer_positive?(verdict_id + ' - post id', self.postId, 'Comment post id')
-      log.va_integer_positive?(verdict_id + ' - id', self.id, 'Comment id')
-      log.va_string_not_empty?(verdict_id + ' - name', self.name, 'Comment name')
-      log.va_string_not_empty?(verdict_id + ' - email', self.email, 'Comment email')
-      log.va_string_not_empty?(verdict_id + ' - body', self.body, 'Comment body')
+      log.verdict_assert_integer_positive?(verdict_id + ' - post id', self.postId, 'Comment post id')
+      log.verdict_assert_integer_positive?(verdict_id + ' - id', self.id, 'Comment id')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - name', self.name, 'Comment name')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - email', self.email, 'Comment email')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - body', self.body, 'Comment body')
     end
   end
 

--- a/examples/rest_api/data/company.rb
+++ b/examples/rest_api/data/company.rb
@@ -24,9 +24,9 @@ class Company < BaseClassForData
   Contract Log, String => Bool
   def verdict_valid?(log, verdict_id)
     if log.verdict_assert_instance_of?(verdict_id + ' - class', Company, self, 'First object is of class Company')
-      log.va_string_not_empty?(verdict_id + ' - name', self.name, 'Company name')
-      log.va_string_not_empty?(verdict_id + ' - catchPhrase', self.catchPhrase, 'Company catchPhrase')
-      log.va_string_not_empty?(verdict_id + ' - bs', self.bs, 'Company bs')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - name', self.name, 'Company name')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - catchPhrase', self.catchPhrase, 'Company catchPhrase')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - bs', self.bs, 'Company bs')
     end
   end
 

--- a/examples/rest_api/data/geo.rb
+++ b/examples/rest_api/data/geo.rb
@@ -25,8 +25,8 @@ class Geo < BaseClassForData
   Contract Log, String => Bool
   def verdict_valid?(log, verdict_id)
     if log.verdict_assert_instance_of?(verdict_id + ' - class', Geo, self, 'First object is of class Geo')
-      log.va_in_delta?(verdict_id + ' - lat', 0, self.lat, 90, 'Geo lat')
-      log.va_in_delta?(verdict_id + ' - lng', 0, self.lng, 90, 'Geo lng')
+      log.verdict_assert_in_delta?(verdict_id + ' - lat', 0, self.lat, 90, 'Geo lat')
+      log.verdict_assert_in_delta?(verdict_id + ' - lng', 0, self.lng, 90, 'Geo lng')
     end
   end
 

--- a/examples/rest_api/data/photo.rb
+++ b/examples/rest_api/data/photo.rb
@@ -30,11 +30,11 @@ class Photo < BaseClassForResource
   Contract Log, String => Bool
   def verdict_valid?(log, verdict_id)
     if log.verdict_assert_instance_of?(verdict_id + ' - class', Photo, self, 'First object is of class Photo')
-      log.va_integer_positive?(verdict_id + ' - album id', self.albumId, 'Photo album id')
-      log.va_integer_positive?(verdict_id + ' - id', self.id, 'Photo id')
-      log.va_string_not_empty?(verdict_id + ' - title', self.title, 'Photo title')
-      log.va_string_not_empty?(verdict_id + ' - url', self.url, 'Photo url')
-      log.va_string_not_empty?(verdict_id + ' - thumbnailUrl', self.thumbnailUrl, 'Photo thumbnailUrl')
+      log.verdict_assert_integer_positive?(verdict_id + ' - album id', self.albumId, 'Photo album id')
+      log.verdict_assert_integer_positive?(verdict_id + ' - id', self.id, 'Photo id')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - title', self.title, 'Photo title')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - url', self.url, 'Photo url')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - thumbnailUrl', self.thumbnailUrl, 'Photo thumbnailUrl')
     end
   end
 

--- a/examples/rest_api/data/post.rb
+++ b/examples/rest_api/data/post.rb
@@ -24,10 +24,10 @@ class Post < BaseClassForResource
   Contract Log, String => Bool
   def verdict_valid?(log, verdict_id)
     if log.verdict_assert_instance_of?(verdict_id + ' - class', Post, self, 'First object is of class Post')
-      log.va_integer_positive?(verdict_id + ' - id', self.id, 'Post id')
-      log.va_integer_positive?(verdict_id + ' - user id', self.userId, 'Post user id')
-      log.va_string_not_empty?(verdict_id + ' - title', self.title, 'Post title')
-      log.va_string_not_empty?(verdict_id + ' - body', self.body, 'Post body')
+      log.verdict_assert_integer_positive?(verdict_id + ' - id', self.id, 'Post id')
+      log.verdict_assert_integer_positive?(verdict_id + ' - user id', self.userId, 'Post user id')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - title', self.title, 'Post title')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - body', self.body, 'Post body')
     end
   end
 

--- a/examples/rest_api/data/todo.rb
+++ b/examples/rest_api/data/todo.rb
@@ -28,10 +28,10 @@ class Todo < BaseClassForResource
   Contract Log, String => Bool
   def verdict_valid?(log, verdict_id)
     if log.verdict_assert_instance_of?(verdict_id + ' - class', Todo, self, 'First object is of class Todo')
-      log.va_integer_positive?(verdict_id + ' - user id', self.userId, 'Todo user id')
-      log.va_integer_positive?(verdict_id + ' - id', self.id, 'Todo id')
-      log.va_string_not_empty?(verdict_id + ' - title', self.title, 'Todo title')
-      log.va_boolean?(verdict_id + ' - completed', self.completed, 'Todo completed')
+      log.verdict_assert_integer_positive?(verdict_id + ' - user id', self.userId, 'Todo user id')
+      log.verdict_assert_integer_positive?(verdict_id + ' - id', self.id, 'Todo id')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - title', self.title, 'Todo title')
+      log.verdict_assert_boolean?(verdict_id + ' - completed', self.completed, 'Todo completed')
     end
   end
 

--- a/examples/rest_api/data/user.rb
+++ b/examples/rest_api/data/user.rb
@@ -36,12 +36,12 @@ class User < BaseClassForResource
   Contract Log, String => Bool
   def verdict_valid?(log, verdict_id)
     if log.verdict_assert_instance_of?(verdict_id + ' - class', User, self, 'First object is of class User')
-      log.va_integer_positive?(verdict_id + ' - id', self.id, 'User id')
-      log.va_string_not_empty?(verdict_id + ' - name', self.name, 'User name')
-      log.va_string_not_empty?(verdict_id + ' - username', self.username, 'User username')
-      log.va_string_not_empty?(verdict_id + ' - email', self.email, 'User email')
-      log.va_string_not_empty?(verdict_id + ' - phone', self.phone, 'User phone')
-      log.va_string_not_empty?(verdict_id + ' - website', self.website, 'User website')
+      log.verdict_assert_integer_positive?(verdict_id + ' - id', self.id, 'User id')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - name', self.name, 'User name')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - username', self.username, 'User username')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - email', self.email, 'User email')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - phone', self.phone, 'User phone')
+      log.verdict_assert_string_not_empty?(verdict_id + ' - website', self.website, 'User website')
       address.verdict_valid?(log, verdict_id + ' - address')
       company.verdict_valid?(log, verdict_id + ' - company')
     end

--- a/examples/rest_api/endpoints/base_classes/base_class_for_delete_id.rb
+++ b/examples/rest_api/endpoints/base_classes/base_class_for_delete_id.rb
@@ -17,7 +17,7 @@ class BaseClassForDeleteId < BaseClassForEndpoint
       object_to_delete.log(log, data_class_name + ' to delete')
       payload = self.call(client, object_to_delete)
       log.section('Evaluation') do
-        log.va_nil?('payload nil', payload, 'Payload nil')
+        log.verdict_assert_nil?('payload nil', payload, 'Payload nil')
         klass = ObjectHelper.get_class_for_class_name(data_class_name)
         klass.verdict_not_exist?(client, log, verdict_id, object_to_delete)
       end


### PR DESCRIPTION
…to long form, for clarity.